### PR TITLE
Filter objects only after "name" property is assigned

### DIFF
--- a/src/modules/models/script_models/script.ts
+++ b/src/modules/models/script_models/script.ts
@@ -114,9 +114,6 @@ export default class Script {
             throw new CommandInitializationError(this.logger.getResourceString(RESOURCES.noObjectsDefinedInPackageFile));
         }
 
-        // Make each object appear only once in the script
-        this.objects = Common.distinctArray(this.objects, "name");
-
         // Assign orgs
         Object.assign(this.sourceOrg, {
             script: this,
@@ -139,6 +136,9 @@ export default class Script {
         this.objects.forEach(object => {
             object.setup(this);
         });
+
+        // Make each object appear only once in the script
+        this.objects = Common.distinctArray(this.objects, "name");
     }
 
     /**

--- a/src/modules/models/script_models/script.ts
+++ b/src/modules/models/script_models/script.ts
@@ -137,7 +137,7 @@ export default class Script {
             object.setup(this);
         });
 
-        // Make each object appear only once in the script 
+        // Make each object appear only once in the script
         this.objects = Common.distinctArray(this.objects, "name");
     }
 

--- a/src/modules/models/script_models/script.ts
+++ b/src/modules/models/script_models/script.ts
@@ -137,7 +137,7 @@ export default class Script {
             object.setup(this);
         });
 
-        // Make each object appear only once in the script
+        // Make each object appear only once in the script 
         this.objects = Common.distinctArray(this.objects, "name");
     }
 


### PR DESCRIPTION
#27 
Filter objects only after "name" property is assigned in the setup function (when query is parsed).
