### PR TITLE
Add skip_lines_with_error to csv parser call

### DIFF
--- a/src/modules/components/api_engines/bulkApiV2_0Engine.ts
+++ b/src/modules/components/api_engines/bulkApiV2_0Engine.ts
@@ -193,7 +193,7 @@ export class BulkApiV2_0Engine extends ApiEngineBase implements IApiEngine {
         // SUCCESS RESULT
         return csvChunk.records;
     }
-    // ----------------------- ---------------- -------------------------------------------    
+    // ----------------------- ---------------- -------------------------------------------
 
 
     /**
@@ -288,7 +288,7 @@ export class BulkApiV2_0Engine extends ApiEngineBase implements IApiEngine {
     }
 
     /**
-     * Closes bulk job and forces csv content to be uploaded 
+     * Closes bulk job and forces csv content to be uploaded
      *
      * @param {string} contentUrl Content url returned by createBulkJob()
      * @returns {Promise<ApiInfo>}
@@ -329,7 +329,7 @@ export class BulkApiV2_0Engine extends ApiEngineBase implements IApiEngine {
      * Polls  job for the status
      *
      * @param {string} contentUrl Content url returned by createBulkJob()
-     * @returns {Promise<ApiInfo>} 
+     * @returns {Promise<ApiInfo>}
      * @memberof BulkAPI2sf
      */
     async pollBulkJobAsync(contentUrl: string): Promise<ApiInfo> {
@@ -364,7 +364,7 @@ export class BulkApiV2_0Engine extends ApiEngineBase implements IApiEngine {
     }
 
     /**
-     * Asks the server for the job status by given polling 
+     * Asks the server for the job status by given polling
      * interval and returns job status when the job is completed or failed
      *
      * @param {string} contentUrl
@@ -456,9 +456,10 @@ export class BulkApiV2_0Engine extends ApiEngineBase implements IApiEngine {
                     }
 
                     try {
-                        
+
                         let csv = parse(body, {
                             skip_empty_lines: true,
+                            skip_lines_with_error: true,
                             cast: self._csvCast
                         });
 
@@ -552,6 +553,7 @@ export class BulkApiV2_0Engine extends ApiEngineBase implements IApiEngine {
                 if (!error && response.statusCode == 200) {
                     let csv = parse(body, {
                         skip_empty_lines: true,
+                        skip_lines_with_error: true,
                         cast: self._csvCast
                     });
                     let unprocessedRecords = Common.transformArrayOfArrays(csv);

--- a/src/modules/components/common_components/common.ts
+++ b/src/modules/components/common_components/common.ts
@@ -691,6 +691,7 @@ export class Common {
           const records = parse(input, {
             columns: ___columns,
             skip_empty_lines: true,
+            skip_lines_with_error : true,
             cast: ___csvCast
           });
           resolve([...records]);
@@ -719,6 +720,7 @@ export class Common {
             const records = parse(input, {
               columns: true,
               skip_empty_lines: true,
+              skip_lines_with_error : true,
               cast: ___csvCast
             });
             resolve([...records]);


### PR DESCRIPTION
I happened to have errors while retrieving records from BulkAPI 

Sorry, can't say on each line exactly ( > 500000 and not detail in logs), but adding this property to CSV parser allowed me to bypass this issue :)

The error was this one: https://github.com/adaltas/node-csv/blob/40fd615ed54a3a120dd8e0f1d24203531da8eb65/packages/csv-parse/lib/index.js#L833

Maybe you would like to add an option to activate it, instead of activating it by default ?