### PR TITLE
Fixing Smart Order issue with MasterDetail object that has multiple children

### DIFF
--- a/src/modules/models/job_models/migrationJob.ts
+++ b/src/modules/models/job_models/migrationJob.ts
@@ -218,7 +218,7 @@ export default class MigrationJob {
                     let rightIsParentMasterDetailOfLeft = leftTask.scriptObject.parentMasterDetailObjects.some(object => object.name == rightTask.sObjectName);
                     let leftTaskIndex = self.tasks.indexOf(leftTask);
                     let rightTaskIndex = self.tasks.indexOf(rightTask);
-                    if (rightIsParentMasterDetailOfLeft) {
+                    if (rightIsParentMasterDetailOfLeft && rightTaskIndex > leftTaskIndex) {
                         // Swape places and put right before left
                         self.tasks.splice(rightTaskIndex, 1);
                         self.tasks.splice(leftTaskIndex, 0, rightTask);


### PR DESCRIPTION
Current implementation of [`___putMasterDetailsBefore`](https://github.com/forcedotcom/SFDX-Data-Move-Utility/blob/a647be5107dda0a700be2d8ea1dc2ea5d002a350/src/modules/models/job_models/migrationJob.ts#L211) does not check if MasterDetail object was moved already in-front in same loop, which leads to unpredictable results and sometimes puts MasterDetail after children.

This happens when one MasterDetail object has multiple children and in original order children are in-front of it one after another.

Proposed check is already implemented in [`___updateQueryTaskOrder`](https://github.com/forcedotcom/SFDX-Data-Move-Utility/blob/a647be5107dda0a700be2d8ea1dc2ea5d002a350/src/modules/models/job_models/migrationJob.ts#L182) on line [199](https://github.com/forcedotcom/SFDX-Data-Move-Utility/blob/a647be5107dda0a700be2d8ea1dc2ea5d002a350/src/modules/models/job_models/migrationJob.ts#L199)

