### PR TITLE
ci: use context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,11 @@ orbs:
 workflows:
   version: 2
   test-and-release:
-    jobs:      
+    jobs:
       - release-management/release-package:
           sign: true
           github-release: true
+          context: AWS
           filters:
             branches:
               only: master


### PR DESCRIPTION
we currently have aws keys stored in circle CI envs.

This change puts them in the signing job using a context so they only have to be rotated in one place for all `forcedotcom` repos.
