### PR TITLE
Fixing Smart Order issue

### DIFF
--- a/src/modules/models/job_models/migrationJob.ts
+++ b/src/modules/models/job_models/migrationJob.ts
@@ -218,7 +218,7 @@ export default class MigrationJob {
           let rightIsParentMasterDetailOfLeft = leftTask.scriptObject.parentMasterDetailObjects.some(object => object.name == rightTask.sObjectName);
           let leftTaskIndex = self.tasks.indexOf(leftTask);
           let rightTaskIndex = self.tasks.indexOf(rightTask);
-          if (rightIsParentMasterDetailOfLeft) {
+          if (rightIsParentMasterDetailOfLeft && rightTaskIndex > leftTaskIndex) {
             // Swape places and put right before left
             self.tasks.splice(rightTaskIndex, 1);
             self.tasks.splice(leftTaskIndex, 0, rightTask);


### PR DESCRIPTION
Master Object with multiple nested children is being put after children, which leads to failed import.

Issue occurs during import from CVS files into brand new Scratch Org.

Additional information and sample is provided here: https://github.com/forcedotcom/SFDX-Data-Move-Utility/pull/411#issuecomment-1019353836

Exact same fix was applied to `___updateQueryTaskOrder` function on line 199 as part of following PR - https://github.com/forcedotcom/SFDX-Data-Move-Utility/blob/master/src/modules/models/job_models/migrationJob.ts#L199

I'm proposing to do same check in `___putMasterDetailsBefore` function, which fixes the behaviour.