### PR TITLE
fix:Log warning in case 'targetRecordsFilter' SQL failed

### DIFF
--- a/messages/resources.json
+++ b/messages/resources.json
@@ -189,6 +189,7 @@
     "writingToFile": "{%s} Creating the file %s ...",
     "nothingUpdated": "Nothing was updated.",
     "skippedUpdatesWarning": "{%s} %s target records remained untouched, since they do not differ from the corresponding source records.",
+    "skippedTargetRecordsFilterWarning": "One 'targetRecordsFilter' could not be applied: %s.",
     "missingParentLookupsPrompt": "{%s} %s missing parent lookup records were found. See %s file for the details.",
     "updatingSummary": "Data processing summary.",
     "updatingTotallyUpdated": "{%s} Totally processed %s records.",

--- a/src/modules/components/common_components/logger.ts
+++ b/src/modules/components/common_components/logger.ts
@@ -210,6 +210,7 @@ export enum RESOURCES {
   writingToFile = "writingToFile",
   nothingUpdated = "nothingUpdated",
   skippedUpdatesWarning = "skippedUpdatesWarning",
+  skippedTargetRecordsFilterWarning = "skippedTargetRecordsFilterWarning",
   missingParentLookupsPrompt = "missingParentLookupsPrompt",
   updatingSummary = "updatingSummary",
   updatingTotallyUpdated = "updatingTotallyUpdated",

--- a/src/modules/models/job_models/migrationJobTask.ts
+++ b/src/modules/models/job_models/migrationJobTask.ts
@@ -1536,6 +1536,7 @@ export default class MigrationJobTask {
             resolve(selectedRecords);
           });
         } catch (ex) {
+          self.logger.warn(RESOURCES.skippedTargetRecordsFilterWarning, ex.message);
           resolve(records);
         }
       });


### PR DESCRIPTION
I recently made a mistake in my `targetRecordsFilter` syntax when trying to load from CSV like this:

```json
"objects" : [
   {
	"query": "SELECT Id, readonly_false FROM Product2",
	"excludedFields" : ["ExternalDataSourceId"],
	"operation": "Upsert",
	"externalId": "MyExternalId",
	"targetRecordsFilter": "Name LIKE '%something%'"
  }
]
```

Note the double single quotes at the end. If you run a query like this directly against `alasql`, you will get an error message like this:

```
SyntaxError: Parse error on line 1:
...me  LIKE '%something%''
----------------------------^
Expecting 'LITERAL', 'BRALITERAL', 'EOF', 'EndTransaction', 'WITH', 'COMMA', 'AS', 'LPAR', 'RPAR', 'SEARCH', 'PIVOT', 'FOR', 'UNPIVOT', 'IN', 'REMOVE', 'LIKE', 'ARROW', 'DOT', 'ORDER', 'DOTDOT', 'CARET', 'EQ', 'WHERE', 'OF', 'CLASS', 'NUMBER', 'STRING', 'SLASH', 'VERTEX', 'EDGE', 'EXCLAMATION', 'SHARP', 'MODULO', 'GT', 'LT', 'GTGT', 'LTLT', 'DOLLAR', 'AT', 'SET', 'TO', 'VALUE', 'ROW', 'COLON', 'NOT', 'IF', 'UNION', 'ALL', 'ANY', 'INTERSECT', 'EXCEPT', 'AND', 'OR', 'PATH', 'RETURN', 'REPEAT', 'PLUS', 'STAR', 'QUESTION', 'FROM', 'DISTINCT', 'UNIQUE', 'SELECT', 'INTO', 'CROSS', 'OUTER', 'NATURAL', 'JOIN', 'INNER', 'LEFT', 'RIGHT', 'FULL', 'SEMI', 'ANTI', 'ON', 'USING', 'GROUP', 'HAVING', 'FIRST', 'LAST', 'DIRECTION', 'COLLATE', 'LIMIT', 'OFFSET', 'JAVASCRIPT', 'CREATE', 'SUM', 'TOTAL', 'COUNT', 'MIN', 'MAX', 'AVG', 'AGGR', 'ARRAY', 'REPLACE', 'NSTRING', 'NULL', 'RBRA', 'END', 'WHEN', 'THEN', 'ELSE', 'REGEXP', 'TILDA', 'GLOB', 'ESCAPE', 'NOT_LIKE', 'BARBAR', 'MINUS', 'AMPERSAND', 'BAR', 'GE', 'LE', 'EQEQ', 'EQEQEQ', 'NE', 'NEEQEQ', 'NEEQEQEQ', 'BETWEEN', 'NOT_BETWEEN', 'IS', 'DOUBLECOLON', 'UPDATE', 'DELETE', 'INSERT', 'DEFAULT', 'IDENTITY', 'CHECK', 'PRIMARY', 'FOREIGN', 'REFERENCES', 'DROP', 'ALTER', 'RENAME', 'ATTACH', 'DETACH', 'USE', 'SHOW', 'SOURCE', 'ASSERT', 'ATLBRA', 'LCUR', 'RCUR', 'COMMIT', 'ROLLBACK', 'BEGIN', 'WHILE', 'CONTINUE', 'BREAK', 'PRINT', 'REQUIRE', 'ECHO', 'DECLARE', 'TRUNCATE', 'MERGE', 'OUTPUT', 'CONTENT', 'COLONDASH', 'QUESTIONDASH', 'CALL', 'REINDEX', 'GO', 'SEMICOLON', got 'INVALID'
```

`sfdmu` currently just goes on with further processing without even noticing me. In my case this leaded to unwanted products being loded to SF.

In my opinion it would be great to have a least a warning popping up in the console. One could also imagine stopping the further processing.