### PR TITLE
[BUGFIX] When a chunk of files from the exportFiles plugin gets an error in upload, all files are set as failed, even when other chunks get successfully uploaded

### DIFF
--- a/src/addons/components/sfdmu-run/sfdmuRunAddonRuntime.ts
+++ b/src/addons/components/sfdmu-run/sfdmuRunAddonRuntime.ts
@@ -420,7 +420,7 @@ export default class SfdmuRunAddonRuntime extends AddonRuntime implements ISfdmu
           }
         });
       } else {
-        sourceVersions.forEach(sourceVersion => sourceVersion.isError = true);
+        versionsToUpload.forEach(uploadVersion => newToSourceVersionMap.get(uploadVersion).isError = true);
       }
     };
     // -------------------------------------------------------


### PR DESCRIPTION
When there is an error in one or more chunks of files from the plugin exportFiles, the property "isError" is set as true for all the files from the other chunks, even those successfully uploaded.

This leads to the plugin not creating the "ContentDocumentLink" records in the end of the process, since it thinks all of the uploads failed and there is nothing to create. When this happens, you end up with a lot of "ContentDocuments" created but not linked to the records they should link, wasting storage and with no easy way to do that linking process automatically.

This modification makes sure only the files from the chunks which failed to upload gets its "isError" property set as true.