### PR TITLE
fix: Switch to transform streams for csv-writer to avoid crash when writing huge CSVs

### DIFF
--- a/src/modules/components/common_components/common.ts
+++ b/src/modules/components/common_components/common.ts
@@ -43,6 +43,7 @@ import {
   RESOURCES,
 } from './logger';
 import { CONSTANTS } from './statics';
+import { Transform } from 'stream';
 
 const parse = (parse2 as any).parse || parse2;
 
@@ -50,7 +51,6 @@ const glob = (glob2 as any).glob || glob2;
 
 const { closest } = require('fastest-levenshtein')
 
-const createCsvWriter = require('csv-writer').createObjectCsvWriter;
 const createCsvStringifier = require('csv-writer').createObjectCsvStringifier;
 
 
@@ -836,18 +836,51 @@ export class Common {
         }
         return;
       }
-      const csvWriter = createCsvWriter({
-        fieldDelimiter: Common.csvWriteFileDelimiter,
-        header: (columns || Object.keys(array[0])).map(x => {
-          return {
-            id: x,
-            title: x
-          }
-        }),
-        path: filePath,
-        encoding: "utf8"
-      });
-      return csvWriter.writeRecords(array);
+
+      class CsvTransformStream extends Transform {
+        _first: boolean
+        _stringifier: any
+
+        constructor() {
+          super({objectMode: true});
+
+          this._first = true;
+          this._stringifier = createCsvStringifier({
+            fieldDelimiter: Common.csvWriteFileDelimiter,
+            header: (columns || Object.keys(array[0])).map(x => {
+              return {
+                id: x,
+                title: x
+              }
+            }),
+          })
+        }
+
+        _transform(record, encoding, callback) {
+            //passes records one by one
+            const line = this._stringifier.stringifyRecords([record])
+            if(this._first) {
+              this._first = false;
+              callback(null, this._stringifier.getHeaderString() + line)
+            } else {
+              callback(null, line)
+            }
+        }
+      }
+
+      const csvTransformStream = new CsvTransformStream();
+      csvTransformStream.pipe(fs.createWriteStream(filePath));
+
+      for(const record of array) {
+        csvTransformStream.write(record);
+      }
+
+      csvTransformStream.end();
+
+      return new Promise((resolve, reject) => {
+        csvTransformStream.on('finish', resolve)
+        csvTransformStream.on('error', reject)
+      })
     } catch (ex) {
       throw new CommandExecutionError(this.logger.getResourceString(RESOURCES.writingCsvFileError, filePath, ex.message));
     }


### PR DESCRIPTION
When writing a CSV that is too large (GBs) the app crashes with a `RangeError: Invalid string length`. 

From `csv-writer`'s documentation: 

_However, if you need to keep writing large data to a certain file, you would want to create node's transform stream and use CsvStringifier, which is explained later, inside it , and pipe the stream into a file write stream._

This PR switches to a transform stream to fix the issue. Tested with a 1 GB+ CSV MissingParentRecordsReport.csv, and it seems to work fine.