### PR TITLE
fix: Wait for CSV file stream

### DIFF
--- a/src/modules/components/common_components/common.ts
+++ b/src/modules/components/common_components/common.ts
@@ -44,6 +44,7 @@ import {
   RESOURCES,
 } from './logger';
 import { CONSTANTS } from './statics';
+import { Transform } from 'stream';
 
 const parse = (parse2 as any).parse || parse2;
 
@@ -51,7 +52,6 @@ const glob = (glob2 as any).glob || glob2;
 
 const { closest } = require('fastest-levenshtein')
 
-const createCsvWriter = require('csv-writer').createObjectCsvWriter;
 const createCsvStringifier = require('csv-writer').createObjectCsvStringifier;
 
 
@@ -837,18 +837,54 @@ export class Common {
         }
         return;
       }
-      const csvWriter = createCsvWriter({
-        fieldDelimiter: Common.csvWriteFileDelimiter,
-        header: (columns || Object.keys(array[0])).map(x => {
-          return {
-            id: x,
-            title: x
-          }
-        }),
-        path: filePath,
-        encoding: "utf8"
-      });
-      return csvWriter.writeRecords(array);
+
+      class CsvTransformStream extends Transform {
+        _first: boolean
+        _stringifier: any
+
+        constructor() {
+          super({objectMode: true});
+
+          this._first = true;
+          this._stringifier = createCsvStringifier({
+            fieldDelimiter: Common.csvWriteFileDelimiter,
+            header: (columns || Object.keys(array[0])).map(x => {
+              return {
+                id: x,
+                title: x
+              }
+            }),
+          })
+        }
+
+        _transform(record, encoding, callback) {
+            //passes records one by one
+            const line = this._stringifier.stringifyRecords([record])
+            if(this._first) {
+              this._first = false;
+              callback(null, this._stringifier.getHeaderString() + line)
+            } else {
+              callback(null, line)
+            }
+        }
+      }
+
+      const fileStream = fs.createWriteStream(filePath);
+      const csvTransformStream = new CsvTransformStream();
+
+      csvTransformStream.pipe(fileStream);
+
+      for(const record of array) {
+        csvTransformStream.write(record);
+      }
+
+      csvTransformStream.end();
+
+      // Wait for file to be fully written #618
+      return new Promise((resolve, reject) => {
+        fileStream.on('finish', resolve);
+        fileStream.on('error', reject);
+      })
     } catch (ex) {
       throw new CommandExecutionError(this.logger.getResourceString(RESOURCES.writingCsvFileError, filePath, ex.message));
     }


### PR DESCRIPTION
* Stream behaviour was introduced with #617
* We have been waiting for the csvTransformStream only
* FileStream was not fully flushed so we missed CSV records #618

@bgandin I readded your code but basically changed the `Promise` to wait for the `fileStream` instead of the `csvTransformSteam`

![image](https://github.com/forcedotcom/SFDX-Data-Move-Utility/assets/19730957/5550f149-fa03-465f-96dd-19e51b86d8fe)

Would be great if you could test this with your 1GB files you mentioned in #617 

CC: @hknokh2 