### PR TITLE
fix: value mapping fix when mapping false checkbox fields

### DIFF
--- a/src/modules/models/job_models/migrationJobTask.ts
+++ b/src/modules/models/job_models/migrationJobTask.ts
@@ -1892,7 +1892,7 @@ export default class MigrationJobTask {
 
         records.forEach((record: any) => {
           let newValue: any;
-          let rawValue = (String(record[field] || "")).trim();
+          let rawValue = ((typeof record[field] === 'undefined') ? "" : String(record[field])).trim();
           if (regexp) {
             // Use regex
             try {


### PR DESCRIPTION
When value mapping checkbox fields, the false values were not being picked up for mapping This is because the below check treated the value as falsey and set the value to an empty string. However, false is a valid value for checkbox fields. 

The check has been updated to explicitly check for undefined rather than just a falsey value.

This should resolve [this open issue](https://github.com/forcedotcom/SFDX-Data-Move-Utility/issues/611).