### PR TITLE
fix: add keywords for better discoverability via npmjs.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,15 @@
     "/oclif.manifest.json"
   ],
   "homepage": "https://help.sfdmu.com",
-  "keywords": [],
+  "keywords": [
+    "force",
+    "salesforce",
+    "salesforcedx",
+    "sf",
+    "sf-plugin",
+    "sfdx",
+    "sfdx-plugin"
+  ],
   "oclif": {
     "commands": "./lib/commands",
     "bin": "sfdx",


### PR DESCRIPTION
These are the default keywords of a generated sf plugin https://github.com/salesforcecli/plugin-dev/blob/main/test/fixtures/plugin-test/package.json#L35-L43