### PR TITLE
feat: Added support to use order by in SOQL queries for the core:ExportFiles Add On

### DIFF
--- a/src/addons/components/sfdmu-run/sfdmuRunAddonRuntime.ts
+++ b/src/addons/components/sfdmu-run/sfdmuRunAddonRuntime.ts
@@ -119,10 +119,11 @@ export default class SfdmuRunAddonRuntime extends AddonRuntime implements ISfdmu
    * @param {string} [fieldName="Id"] The field of the IN clause
    * @param {string} sObjectName The object api name to select
    * @param {string[]} valuesIN The array of values to use in the IN clause
+   * @param {string} orderBy Order returned records by a field
    * @returns {string[]} The array of SOQLs depend on the given values to include all of them
    */
-  createFieldInQueries(selectFields: string[], fieldName: string = "Id", sObjectName: string, valuesIN: string[], whereClause?: string): string[] {
-    return Common.createFieldInQueries(selectFields, fieldName, sObjectName, valuesIN, whereClause);
+  createFieldInQueries(selectFields: string[], fieldName: string = "Id", sObjectName: string, valuesIN: string[], whereClause?: string, orderBy?: string): string[] {
+    return Common.createFieldInQueries(selectFields, fieldName, sObjectName, valuesIN, whereClause, orderBy);
   }
 
 

--- a/src/addons/modules/sfdmu-run/ExportFiles/index.ts
+++ b/src/addons/modules/sfdmu-run/ExportFiles/index.ts
@@ -40,6 +40,11 @@ interface IOnExecuteArguments {
    */
   targetWhere: string;
 
+  /**
+   * Order how the content document links are populated.
+   * ORDER BY [contentDocumentLinkOrderBy].
+   */
+  contentDocumentLinkOrderBy: string;
 
   /**
    * For optimized porocessing, files are grouped into multiple chunks and uploaded sequentially.
@@ -297,7 +302,7 @@ export default class ExportFiles extends SfdmuRunAddonModule {
           ['Id', 'LinkedEntityId', 'ContentDocumentId', 'ShareType', 'Visibility'],
           'LinkedEntityId',
           'ContentDocumentLink',
-          [...task.sourceTaskData.idRecordsMap.keys()]);
+          [...task.sourceTaskData.idRecordsMap.keys()], '', args.contentDocumentLinkOrderBy);
 
         let contentDocLinks = await _self.runtime.queryMultiAsync(true, queries);
         sourceFiles.recIdToDocLinks = Common.arrayToMapMulti(contentDocLinks, ['LinkedEntityId']);

--- a/src/modules/components/common_components/common.ts
+++ b/src/modules/components/common_components/common.ts
@@ -1190,6 +1190,7 @@ export class Common {
      * @param {string} [fieldName="Id"] The field name to use in the  WHERE Field IN (Values) clause
      * @param {Array<string>} valuesIN Values to use in in the WHERE Field IN (Values) clause
      * @param {string} whereClause The additional where clause to add besides the IN, like (Id Name ('Name1', 'Name2)) AND (Field__c = 'value')
+     * @param {string} orderByClause Specify how records are ordered i.e. ORDER By CreatedDate
      * @returns {Array<string>} Returns an array of SOQLs
      * @memberof SfdxUtils
      */
@@ -1198,7 +1199,8 @@ export class Common {
     fieldName: string = "Id",
     sObjectName: string,
     valuesIN: Array<string>,
-    whereClause?: string): Array<string> {
+    whereClause?: string,
+    orderByClause?: string): Array<string> {
 
     if (valuesIN.length == 0) {
       return new Array<string>();
@@ -1218,6 +1220,11 @@ export class Common {
       parsedWhere = whereClause && parseQuery('SELECT Id FROM Account WHERE (' + whereClause + ')');
       //parsedWhere.where.left.openParen = 1;
       //parsedWhere.where.left.closeParen = 1;
+    }
+
+    let parsedOrderBy: Query;
+    if(orderByClause){
+      parsedOrderBy = orderByClause && parseQuery('SELECT Id FROM Account ORDER BY ' + orderByClause + '')
     }
 
 
@@ -1246,6 +1253,11 @@ export class Common {
           tempQuery.where.right = parsedWhere.where;
           tempQuery.where.operator = "AND";
         }
+
+        if(parsedOrderBy){
+          tempQuery.orderBy = parsedOrderBy.orderBy
+        }
+
         yield composeQuery(tempQuery);
 
         whereValues = new Array<string>();


### PR DESCRIPTION
Added the ability to use the ORDER BY keyword for SOQL queries when using the ExportFiles addon. This is useful to specify the order of files, so the most recent files in the source org are also the most recent files in the target org.

Example use case with Conga: https://github.com/forcedotcom/SFDX-Data-Move-Utility/issues/779

Usage is as follows:
```json
"afterAddons": [
  {
    "module": "core:ExportFiles",
    "args": {
      "operation": "Insert",
      "contentDocumentLinkOrderBy": "ContentDocument.CreatedDate DESC"
    }
  }
]
```