### PR TITLE
feat: sourceRecordsFilter option added

### DIFF
--- a/messages/resources.json
+++ b/messages/resources.json
@@ -191,7 +191,7 @@
     "writingToFile": "{%s} Creating the file %s ...",
     "nothingUpdated": "Nothing was updated.",
     "skippedUpdatesWarning": "{%s} %s target records remained untouched, since they do not differ from the corresponding source records.",
-    "skippedsSourceRecordsFilterWarning": "One 'sourceRecordsFilter' could not be applied: %s.",
+    "skippedSourceRecordsFilterWarning": "One 'sourceRecordsFilter' could not be applied: %s.",
     "skippedTargetRecordsFilterWarning": "One 'targetRecordsFilter' could not be applied: %s.",
     "missingParentLookupsPrompt": "{%s} %s missing parent lookup records were found. See %s file for the details.",
     "updatingSummary": "Data processing summary.",

--- a/messages/resources.json
+++ b/messages/resources.json
@@ -191,6 +191,7 @@
     "writingToFile": "{%s} Creating the file %s ...",
     "nothingUpdated": "Nothing was updated.",
     "skippedUpdatesWarning": "{%s} %s target records remained untouched, since they do not differ from the corresponding source records.",
+    "skippedsSourceRecordsFilterWarning": "One 'sourceRecordsFilter' could not be applied: %s.",
     "skippedTargetRecordsFilterWarning": "One 'targetRecordsFilter' could not be applied: %s.",
     "missingParentLookupsPrompt": "{%s} %s missing parent lookup records were found. See %s file for the details.",
     "updatingSummary": "Data processing summary.",

--- a/src/addons/modules/sfdmu-run/custom-addons/package/ISfdmuRunCustomAddonScriptObject.ts
+++ b/src/addons/modules/sfdmu-run/custom-addons/package/ISfdmuRunCustomAddonScriptObject.ts
@@ -30,6 +30,7 @@ export default interface ISfdmuRunCustomAddonScriptObject {
   hardDelete?: boolean;
   updateWithMockData?: boolean;
   //mockCSVData?: boolean;
+  sourceRecordsFilter?: string;
   targetRecordsFilter?: string;
   excluded?: boolean;
   useCSVValuesMapping?: boolean;

--- a/src/modules/components/common_components/common.ts
+++ b/src/modules/components/common_components/common.ts
@@ -1860,5 +1860,30 @@ export class Common {
     return new Promise(resolve => setTimeout(resolve, time));
   }
 
+  static wrapWhereClauseInParenthesis(clause: WhereClause): { beginClause: WhereClause, endClause: WhereClause } {
+    const clone = JSON.parse(JSON.stringify(clause)) as WhereClause;
+    clone.left.openParen = (clone.left.openParen ?? 0) + 1
+    let current = clone;
+    while (current.right) {
+      current = current.right;
+    }
+    current.left.closeParen = (current.left.closeParen || 0) + 1
+    return { beginClause: clone, endClause: current };
+  }
 
+  static mergeWhereClauses(
+    where1?: WhereClause,
+    where2?: WhereClause,
+    operator: LogicalOperator = 'AND',
+  ): WhereClause | undefined {
+    if (!where1 || !where2) return where1 || where2;
+
+    const { beginClause: wrappedWhere1, endClause: endClause1 } = Common.wrapWhereClauseInParenthesis(where1);
+    const { beginClause: wrappedWhere2 } = Common.wrapWhereClauseInParenthesis(where2);
+
+    endClause1.operator = operator;
+    endClause1.right = wrappedWhere2;
+
+    return wrappedWhere1;
+  }
 }

--- a/src/modules/components/common_components/common.ts
+++ b/src/modules/components/common_components/common.ts
@@ -1860,7 +1860,7 @@ export class Common {
     return new Promise(resolve => setTimeout(resolve, time));
   }
 
-  static wrapWhereClauseInParenthesis(clause: WhereClause): { beginClause: WhereClause, endClause: WhereClause } {
+  private static wrapWhereClauseInParenthesis(clause: WhereClause): { beginClause: WhereClause, endClause: WhereClause } {
     const clone = JSON.parse(JSON.stringify(clause)) as WhereClause;
     clone.left.openParen = (clone.left.openParen ?? 0) + 1
     let current = clone;

--- a/src/modules/components/common_components/logger.ts
+++ b/src/modules/components/common_components/logger.ts
@@ -212,6 +212,7 @@ export enum RESOURCES {
   writingToFile = "writingToFile",
   nothingUpdated = "nothingUpdated",
   skippedUpdatesWarning = "skippedUpdatesWarning",
+  skippedSourceRecordsFilterWarning = "skippedSourceRecordsFilterWarning",
   skippedTargetRecordsFilterWarning = "skippedTargetRecordsFilterWarning",
   missingParentLookupsPrompt = "missingParentLookupsPrompt",
   updatingSummary = "updatingSummary",

--- a/src/modules/models/job_models/migrationJobTask.ts
+++ b/src/modules/models/job_models/migrationJobTask.ts
@@ -639,8 +639,12 @@ export default class MigrationJobTask {
       ___filterTargetQuery(tempQuery);
     } else if (this.scriptObject.sourceRecordsFilter) {
       // Add any extra filter conditions to the source query
-      const additionalWhereClause = parseQuery(`SELECT Id FROM ${this.sObjectName} WHERE ${this.scriptObject.sourceRecordsFilter}`).where;
-      tempQuery.where = Common.mergeWhereClauses(tempQuery.where, additionalWhereClause);
+      try {
+        const additionalWhereClause = parseQuery(`SELECT Id FROM ${this.sObjectName} WHERE ${this.scriptObject.sourceRecordsFilter}`).where;
+        tempQuery.where = Common.mergeWhereClauses(tempQuery.where, additionalWhereClause);
+      } catch (ex) {
+        self.logger.warn(RESOURCES.skippedSourceRecordsFilterWarning, ex.message);
+      }
     }
 
     let query = composeQuery(tempQuery);

--- a/src/modules/models/job_models/migrationJobTask.ts
+++ b/src/modules/models/job_models/migrationJobTask.ts
@@ -637,6 +637,10 @@ export default class MigrationJobTask {
     if (isTargetQuery) {
       // Fix target query
       ___filterTargetQuery(tempQuery);
+    } else if (this.scriptObject.sourceRecordsFilter) {
+      // Add any extra filter conditions to the source query
+      const additionalWhereClause = parseQuery(`SELECT Id FROM ${this.sObjectName} WHERE ${this.scriptObject.sourceRecordsFilter}`).where;
+      tempQuery.where = Common.mergeWhereClauses(tempQuery.where, additionalWhereClause);
     }
 
     let query = composeQuery(tempQuery);

--- a/src/modules/models/script_models/scriptObject.ts
+++ b/src/modules/models/script_models/scriptObject.ts
@@ -78,6 +78,7 @@ export default class ScriptObject implements ISfdmuRunScriptObject {
   hardDelete: boolean = false;
   updateWithMockData: boolean = false;
   //mockCSVData: boolean = false;
+  sourceRecordsFilter: string = "";
   targetRecordsFilter: string = "";
   excluded: boolean = false;
   useCSVValuesMapping: boolean = false;


### PR DESCRIPTION
Resolves #935 

Added the `sourceRecordsFilter` which behaves similar to [targetRecordsFilter](https://help.sfdmu.com/full-documentation/advanced-features/target-records-filter) for the ScriptObject .

I've written some basic documentation below.

---

## Overview

**Purpose:** This feature provides an additional method to apply filters only when retrieving them from the Source environment. The filters are not applied to the Target environment.

**Use case:** In some scenarios, the filter condition will only work in the context of the source environment. For example, a parent "Event" object whose "Start Time" depends on children "Block" objects, but the Block objects are not being migrated. This is especially important for `UPSERT` operations, as this relies on equivalent Source and Target objects (by their `externalId`) to be matched to determine whether to `UPDATE` or `INSERT`. With the source-only condition never satisfying any Target objects, only `INSERT` will be used, resulting in duplicate records.

##  Examples of Using Source Record Filter

Supposed you have an Event whose Start Time is calculated by the minimum Block time:

![block-type](https://github.com/user-attachments/assets/d81d7c33-590a-471e-8f2c-47cfb4ea3c77)

The settings below will retrieve all Event records made after 2024 from the Source, then insert all records retrieved to the Target without applying the same filter.

```json
{
  "query": "SELECT Id, Start_Date1__c FROM Event__c",
  "targetRecordsFilter": "CALENDAR_YEAR(Start_Date1__c) >= 2024"
}
```

## Understanding the TargetRecordsFilter Syntax

The `sourceRecordsFilter` uses the **same** syntax as regular SOQL. Please note that this behaviour is slightly different from the `targetRecordsFilter`.