### PR TITLE
fix: filter excludedFields from expandedOriginalQueryFields

### DIFF
--- a/src/modules/models/script/ScriptObject.ts
+++ b/src/modules/models/script/ScriptObject.ts
@@ -556,11 +556,13 @@ export default class ScriptObject {
    * @returns Expanded original query fields.
    */
   public get expandedOriginalQueryFields(): string[] {
+    const excluded = this._getExcludedQueryFields(false);
     const baseFields = [...this._originalFieldsInQuery];
     const expanded = this._expandCompoundFieldNames(baseFields);
     const describe = this.sourceSObjectDescribe ?? this.targetSObjectDescribe;
     const multiselectFields = describe ? this._resolveMultiselectFieldNames(describe) : [];
-    return Common.distinctStringArray([...expanded, ...multiselectFields]);
+    const all = Common.distinctStringArray([...expanded, ...multiselectFields]);
+    return all.filter((f) => !excluded.has(f.toLowerCase()));
   }
 
   /**


### PR DESCRIPTION
Fields listed in `excludedFields` were correctly removed from the SOQL query but still appeared as columns in output CSV files.

**Root cause:** `expandedOriginalQueryFields` combined `_originalFieldsInQuery` (filtered early) with `_resolveMultiselectFieldNames` (unfiltered). When using `SELECT all`, all fields come from the multiselect resolver, so the per-field exclusion check was entirely bypassed.

**Fix:** Move the `excludedFields` filter to after all field sources are merged, so it covers both `_originalFieldsInQuery` and multiselect-resolved fields.

Closes #1206